### PR TITLE
Fix typo in ae-docs Core.mdx

### DIFF
--- a/packages/ae-docs/pages/Core.mdx
+++ b/packages/ae-docs/pages/Core.mdx
@@ -114,7 +114,7 @@ function *program() {
   const item1 = yield ListEffect.takeItem([ 1, 4 ]);
   const item2 = yield ListEffect.takeItem([ 2, 3 ]);
 
-  yield Logger.log(item, item2); // Logs 1 2 then 1 3 then 4 2 and finally 4 3
+  yield Logger.log(item1, item2); // Logs 1 2 then 1 3 then 4 2 and finally 4 3
 
   return item1 + item2;
 }


### PR DESCRIPTION
`item` -> `item1`